### PR TITLE
Namespace cli_parser for correct usage.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ A parser for a single option can be created like this:
 [source,cpp]
 ----
 int width = 0;
-auto cli = cli_parser()
+auto cli = lyra::cli_parser()
     | lyra::opt( width, "width" )
         ["-w"]["--width"]
         ("How wide should it be?");


### PR DESCRIPTION
The `cli_parser` is provided without a namespace. I added the namespace there. 