### PR TITLE
Add CMake Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2019 René Ferdinand Rivera Morell
+# Copyright 2020 Jayesh Vinay Badwaik
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt
@@ -12,10 +13,10 @@
 # via the "add_subdirectory( <path-to-lyra> )" command.
 #
 # Other cmake targets can then use the public target name
-# "BFG::Lyra" in order to express their dependency
+# "bfg::lyra" in order to express their dependency
 # on this library. I.e:
 #
-# target_link_libraries( <my-exe/lib> PUBLIC BFG::Lyra )
+# target_link_libraries( <my-exe/lib> PUBLIC bfg::lyra )
 
 # Only need the basic minimum of project, add_library, and
 # target_include_directories commands.
@@ -24,13 +25,55 @@ cmake_minimum_required( VERSION 3.0 )
 # Don't set VERSION, as that's a pita to keep up to date with the version
 # header. And don't set LANGUAGES as we are multi-language and header
 # only, so it's irrelevant.
-project( BFG_Lyra )
+project( lyra )
 
 # Simple INTERFACE, and header only, library target.
-add_library( bfg_lyra INTERFACE )
+add_library( lyra INTERFACE )
 
 # The only usage requirement is include dir for consumers.
-target_include_directories( bfg_lyra INTERFACE include )
+target_include_directories(
+  lyra
+  INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
 
 # Add an alias to public name.
-add_library( BFG::Lyra ALIAS bfg_lyra )
+add_library( bfg::Lyra ALIAS lyra )
+
+
+## Installation Code
+include(GNUInstallDirs)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${PROJECT_SOURCE_DIR}/data/cmake/lyraConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/lyraConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra
+  )
+
+install(
+  TARGETS lyra
+  EXPORT lyraTarget
+  )
+
+install(
+  EXPORT lyraTarget
+  FILE  lyraTarget.cmake
+  NAMESPACE bfg::
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra/cmake
+  )
+
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include
+  DESTINATION  ${CMAKE_INSTALL_PREFIX}
+  )
+
+install(
+  FILES
+  ${PROJECT_BINARY_DIR}/lyraConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra/cmake/
+  )
+
+
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 # Copyright 2019 René Ferdinand Rivera Morell.
+# Copyright 2020 Jayesh Vinay Badwaik
 
 trigger:
   branches:
@@ -114,6 +115,22 @@ stages:
         b2 toolset=${TOOLSET} cxxstd=${CXXSTD} ${B2_ARGS}
         popd
       displayName: Test
+    - bash: |
+        set -e
+        SOURCE=$PWD
+        mkdir -p ../run
+        mkdir -p ../build
+        pushd ../build
+          cmake -DCMAKE_INSTALL_PREFIX=../run $SOURCE -DCMAKE_CXX_STANDARD=11
+          make install
+        popd
+        mkdir -p ../test
+        pushd ../test
+          cmake -DCMAKE_PREFIX_PATH=$SOURCE/../run  $SOURCE/tests/lib_use_test -DCMAKE_CXX_STANDARD=11
+          make
+          ctest
+        popd
+      displayName: CMake Test
 
   - job: 'Xcode'
     strategy:

--- a/data/cmake/lyraConfig.cmake.in
+++ b/data/cmake/lyraConfig.cmake.in
@@ -1,0 +1,8 @@
+# Copyright 2020 Jayesh Vinay Badwaik
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Target.cmake)

--- a/tests/lib_use_test/CMakeLists.txt
+++ b/tests/lib_use_test/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2020 Jayesh Vinay Badwaik
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+
+cmake_minimum_required( VERSION 3.0 )
+project(base_lib_test)
+
+message(STATUS "${CMAKE_PREFIX_PATH}")
+
+find_package(lyra REQUIRED)
+
+include(CTest)
+add_executable(base_exe base_exe.cpp)
+target_sources(base_exe PRIVATE base_lib.cpp)
+target_include_directories(base_exe PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(base_exe PUBLIC bfg::lyra)
+add_test(NAME base_exe
+         COMMAND base_exe -f)


### PR DESCRIPTION
This PR is intended to fix issue #29. It adds a installable target for CMake and makes it possible to use `lyra` by the standard CMake procedure of `target_link_libraries(yourlib PUBLIC BFG::Lyra)`.