### PR TITLE
Fix CMake ALIAS target case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,7 @@ target_include_directories(
   )
 
 # Add an alias to public name.
-add_library( bfg::Lyra ALIAS lyra )
-
+add_library( bfg::lyra ALIAS lyra )
 
 ## Installation Code
 include(GNUInstallDirs)


### PR DESCRIPTION
**Issue**
The installed CMake target `bfg::lyra` (lower-case `l`) is different from the defined alias `bfg::Lyra` (upper-case `L`).

**Change description**
[Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#using-a-library-defined-in-the-same-cmake-tree-should-look-the-same-as-using-an-external-library) recommends keeping a matching target name for the same CMake tree and as an external package. This change makes the usage of the library consistent (`bfg::lyra`) for both cases.

Fixes #43.