### PR TITLE
Readme: result.errorMessage() -> result.message()

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,7 +85,7 @@ You can use this parser directly like this:
 auto result = cli.parse( { argc, argv } );
 if ( !result )
 {
-	std::cerr << "Error in command line: " << result.errorMessage() << std::endl;
+	std::cerr << "Error in command line: " << result.message() << std::endl;
 	exit(1);
 }
 


### PR DESCRIPTION
result errorMessage() marked as deprecated