### PR TITLE
Fix `command::operator|=` function signature

### DIFF
--- a/include/lyra/command.hpp
+++ b/include/lyra/command.hpp
@@ -59,7 +59,7 @@ class command : public group
 	template <typename P>
 	command & add_argument(P const & p);
 	template <typename P>
-	command & operator|=(parser const & p);
+	command & operator|=(P const & p);
 
 	// Internal.
 	virtual std::unique_ptr<parser> clone() const override
@@ -156,7 +156,7 @@ command & command::add_argument(P const & p)
 	return *this;
 }
 template <typename P>
-command & command::operator|=(parser const & p)
+command & command::operator|=(P const & p)
 {
 	return this->add_argument(p);
 }


### PR DESCRIPTION
The template parameter must be be used in the function signature in order to be deducable.