### PR TITLE
deprecated_parser_customization needs virtual destructor

### DIFF
--- a/include/lyra/detail/deprecated_parser_customization.hpp
+++ b/include/lyra/detail/deprecated_parser_customization.hpp
@@ -38,6 +38,7 @@ struct parser_customization
 {
 	virtual std::string token_delimiters() const = 0;
 	virtual std::string option_prefix() const = 0;
+    virtual ~parser_customization() {}
 };
 
 /* tag::reference[]

--- a/include/lyra/detail/deprecated_parser_customization.hpp
+++ b/include/lyra/detail/deprecated_parser_customization.hpp
@@ -38,7 +38,7 @@ struct parser_customization
 {
 	virtual std::string token_delimiters() const = 0;
 	virtual std::string option_prefix() const = 0;
-    virtual ~parser_customization() {}
+	virtual ~parser_customization() {}
 };
 
 /* tag::reference[]


### PR DESCRIPTION
Classes with virtual methods need virtual destructors.