### PR TITLE
CMake: use system include dirs if used as sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,22 @@ project( lyra )
 add_library( lyra INTERFACE )
 
 # The only usage requirement is include dir for consumers.
-target_include_directories(
-  lyra
-  INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-  )
+if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
+  target_include_directories(
+    lyra
+    INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+else()
+  target_include_directories(
+    lyra
+    SYSTEM
+    INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+endif()
 
 # Add an alias to public name.
 add_library( bfg::lyra ALIAS lyra )


### PR DESCRIPTION
The code should not emit warnings if used as sub-project.
This PR adds CMake logic to detect if Lyra was added using `add_subdirectory` and declares the include directories as SYSTEM includes.