### PR TITLE
Add more entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .bin
+.cache
 .vscode/launch.json
+build
 project-config.jam


### PR DESCRIPTION
- .cache is created by the clangd language server
- build is a conventional build directory often used with CMake