### PR TITLE
Improved help

### DIFF
--- a/include/lyra/arg.hpp
+++ b/include/lyra/arg.hpp
@@ -61,9 +61,9 @@ class arg : public bound_parser<arg>
 		return text;
 	}
 
-	help_text get_help_text(const option_style & style) const override
+	help_text get_help_text(const option_style & style, size_t indent) const override
 	{
-		return { { get_usage_text(style), m_description } };
+		return { { std::string(indent, ' ') + get_usage_text(style), m_description } };
 	}
 
 	using parser::parse;

--- a/include/lyra/arguments.hpp
+++ b/include/lyra/arguments.hpp
@@ -144,12 +144,12 @@ class arguments : public parser
 	}
 
 	// Return a container of the individual help text for the composed parsers.
-	help_text get_help_text(const option_style & style) const override
+	help_text get_help_text(const option_style & style, size_t indent) const override
 	{
 		help_text text;
 		for (auto const & p : parsers)
 		{
-			auto child_help = p->get_help_text(style);
+			auto child_help = p->get_help_text(style, indent + 2);
 			text.insert(text.end(), child_help.begin(), child_help.end());
 		}
 		return text;

--- a/include/lyra/command.hpp
+++ b/include/lyra/command.hpp
@@ -99,21 +99,21 @@ class command : public group
 			+ parsers[1]->get_usage_text(style);
 	}
 
-	help_text get_help_text(const option_style & style) const override
+	help_text get_help_text(const option_style & style, size_t indent) const override
 	{
 		if (expanded_help_details)
 		{
 			help_text text;
 			text.push_back({ "", "" });
-			auto c = parsers[0]->get_help_text(style);
+			auto c = parsers[0]->get_help_text(style, indent + 2);
 			text.insert(text.end(), c.begin(), c.end());
 			text.push_back({ "", "" });
-			auto o = parsers[1]->get_help_text(style);
+			auto o = parsers[1]->get_help_text(style, indent + 2);
 			text.insert(text.end(), o.begin(), o.end());
 			return text;
 		}
 		else
-			return parsers[0]->get_help_text(style);
+			return parsers[0]->get_help_text(style, indent + 2);
 	}
 
 	protected:
@@ -125,7 +125,7 @@ class command : public group
 		// This avoid printing out the "internal" group brackets "{}" for the
 		// command arguments.
 		p.heading("OPTIONS, ARGUMENTS:");
-		for (auto const & cols : parsers[1]->get_help_text(style))
+		for (auto const & cols : parsers[1]->get_help_text(style, 0))
 		{
 			p.option(cols.option, cols.description, 2);
 		}

--- a/include/lyra/literal.hpp
+++ b/include/lyra/literal.hpp
@@ -51,9 +51,11 @@ class literal : public parser
 		return description;
 	}
 
-	help_text get_help_text(const option_style &) const override
+	help_text get_help_text(const option_style &, size_t indent) const override
 	{
-		return { { name, description } };
+		std::string name_str = std::string(indent, ' ') + "\033[1m" + name + "\033[0m";
+		std::string description_str = "\033[3m" + description + "\033[0m";
+		return { { name_str, description_str } };
 	}
 
 	using parser::parse;

--- a/include/lyra/opt.hpp
+++ b/include/lyra/opt.hpp
@@ -101,12 +101,12 @@ class opt : public bound_parser<opt>
 		return usage;
 	}
 
-	help_text get_help_text(const option_style & style) const override
+	help_text get_help_text(const option_style & style, size_t indent) const override
 	{
-		std::string text;
+		std::string text = std::string(indent, ' ');
 		for (auto const & opt_name : opt_names)
 		{
-			if (!text.empty()) text += ", ";
+			if (!text.empty() && !(text.back() == ' ')) text += ", ";
 			text += format_opt(opt_name, style);
 		}
 		if (!m_hint.empty()) ((text += " <") += m_hint) += ">";

--- a/include/lyra/parser.hpp
+++ b/include/lyra/parser.hpp
@@ -139,7 +139,11 @@ class parser
 	[[deprecated]] std::string get_usage_text() const { return ""; }
 	[[deprecated]] std::string get_description_text() const { return ""; }
 
-	virtual help_text get_help_text(const option_style &) const { return {}; }
+	virtual help_text get_help_text(const option_style &, size_t indent) const
+	{
+		(void) indent;
+		return {};
+	}
 	virtual std::string get_usage_text(const option_style &) const
 	{
 		return "";
@@ -197,7 +201,7 @@ class parser
 		printer & p, const option_style & style) const
 	{
 		p.heading("OPTIONS, ARGUMENTS:");
-		for (auto const & cols : get_help_text(style))
+		for (auto const & cols : get_help_text(style, 0))
 		{
 			p.option(cols.option, cols.description, 2);
 		}
@@ -241,7 +245,7 @@ The set of help texts for any options in the sub-parsers to this one, if any.
 
 [source]
 ----
-virtual help_text get_help_text(const option_style &) const;
+virtual help_text get_help_text(const option_style &, size_t indent) const;
 ----
 
 Collects, and returns, the set of help items for the sub-parser arguments in


### PR DESCRIPTION
Indents that provide better readability

Before changes Exemplary output ( Lyra/examples/doc_commands.cpp)

```
adam@PiaskunGTR:~/github/Lyra/examples$ ./develop_doc_commands -h
USAGE:
  develop_doc_commands [-?|-h|--help] [ kill [-?|-h|--help] [-s|--signal <signal>] <process_name> ] [ run [-?|-h|--help] [-v|--verbose] <command> [<command>...] ]

Display usage information.

OPTIONS, ARGUMENTS:
  -?, -h, --help          
                          
  kill                    Terminate the process with the given name.
                          
  -?, -h, --help          
  -s, --signal <signal>   The signal integer to post to the running process. [default: 9]
  <process_name>          The name of the process to search and signal.
                          
  run                     Execute the given command.
                          
  -?, -h, --help          
  -v, --verbose           Show additional output as to what we are doing.
  <command> [<command>...]
                          The command, and arguments, to attempt to run.
```

After changes:
```
adam@PiaskunGTR:~/github/Lyra/examples$ ./doc_commands -h
USAGE:
  doc_commands [-?|-h|--help] [ kill [-?|-h|--help] [-s|--signal <signal>] <process_name> ] [ run [-?|-h|--help] [-v|--verbose] <command> [<command>...] ]

Display usage information.

OPTIONS, ARGUMENTS:
    -?, -h, --help        
                          
      kill        Terminate the process with the given name.
                          
        -?, -h, --help    
        -s, --signal <signal>
                          The signal integer to post to the running process. [default: 9]
        <process_name>    The name of the process to search and signal.
                          
      run         Execute the given command.
                          
        -?, -h, --help    
        -v, --verbose     Show additional output as to what we are doing.
        <command> [<command>...]
                          The command, and arguments, to attempt to run.
```


Help output in mu project with nested subcommands (3 levels)
```
GaiaClient -h
USAGE:
  GaiaClient [-?|-h|--help] [ send [-?|-h|--help] [ param [-I|--id <ParamID>] [-V|--value <Value>] ] [ config [-V|--value <Value>] ] [ ant_mode [ TLE [-s|--satName <Satelite name>] [-f|--fileName <File name>] ] [ park  ] [ standby  ] ] ] [ show [-?|-h|--help] [ param [-I|--id <ParamID>] [-V|--value <Value>] ] [ config [-V|--value <Value>] ] [ ant_mode [ TLE [-s|--satName <Satelite name>] [-f|--fileName <File name>] ] [ park  ] [ standby  ] ] ] [ curl [-?|-h|--help] [ param [-I|--id <ParamID>] [-V|--value <Value>] ] [ config [-V|--value <Value>] ] [ ant_mode [ TLE [-s|--satName <Satelite name>] [-f|--fileName <File name>] ] [ park  ] [ standby  ] ] ] [ save [-a|--address <Gaia daemon address>] [-p|--gaia_port <Gaia daemon port>] ] [ connect  ] [ disconnect  ] [ logger [-f|--loop <EnlessLoop>] ]

Display usage information.

OPTIONS, ARGUMENTS:
  -?, -h, --help          
                          
    send          Send command to Gaia Daemon.
                          
      -?, -h, --help      
                          
        param     Send param command
                          
          -I, --id <ParamID>
                          Param id 0-5
          -V, --value <Value>
                          Param value
                          
        config    Send Anthena Config command
                          
          -V, --value <Value>
                          Param value
                          
        ant_mode  Anthena Mode El Az Tl
                          
                          
            TLE   
                          
              -s, --satName <Satelite name>
                          Satelite name
              -f, --fileName <File name>
                          File name with TLE data
                          
            park  
                          
                          
            standby
                          
                          
                          
    show          Show json messages.
                          
      -?, -h, --help      
                          
        param     Send param command
                          
          -I, --id <ParamID>
                          Param id 0-5
          -V, --value <Value>
                          Param value
                          
        config    Send Anthena Config command
                          
          -V, --value <Value>
                          Param value
                          
        ant_mode  Anthena Mode El Az Tl
                          
                          
            TLE   
                          
              -s, --satName <Satelite name>
                          Satelite name
              -f, --fileName <File name>
                          File name with TLE data
                          
            park  
                          
                          
            standby
                          
                          
                          
    curl          Show curl command.
                          
      -?, -h, --help      
                          
        param     Send param command
                          
          -I, --id <ParamID>
                          Param id 0-5
          -V, --value <Value>
                          Param value
                          
        config    Send Anthena Config command
                          
          -V, --value <Value>
                          Param value
                          
        ant_mode  Anthena Mode El Az Tl
                          
                          
            TLE   
                          
              -s, --satName <Satelite name>
                          Satelite name
              -f, --fileName <File name>
                          File name with TLE data
                          
            park  
                          
                          
            standby
                          
                          
                          
    save          Save given in args param to local settings.
                          
      -a, --address <Gaia daemon address>
                          Remote ACU IP address
      -p, --gaia_port <Gaia daemon port>
                          REST Port for Gaia daemon
                          
    connect       Start connection between gaiaDaemon and Gaia.
                          
                          
    disconnect    Close connection between gaiaDaemon and Gaia.
                          
                          
    logger        Show the Gaia state.
                          
      -f, --loop <EnlessLoop>
                          Persistant checking status
```
_Without this PR help in my project was unreadable and seams that some commands ware duplicated. In Fact there is Cartesian product of (send, show, curl) and (param, config, ant_mode). Moreover ant_mode contains 3. level of subcommands._