### PR TITLE
Fix detection of std::optional type.

### DIFF
--- a/data/single_include/lyra/lyra.hpp
+++ b/data/single_include/lyra/lyra.hpp
@@ -104,9 +104,11 @@ struct is_specialization_of<Primary<Args...>, Primary> : std::true_type
 
 #ifndef LYRA_CONFIG_OPTIONAL_TYPE
 #	ifdef __has_include
-#		if __has_include(<optional>) && __cplusplus >= 201703L
+#		if __has_include(<optional>)
 #			include <optional>
-#			define LYRA_CONFIG_OPTIONAL_TYPE std::optional
+#			if defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
+#				define LYRA_CONFIG_OPTIONAL_TYPE std::optional
+#			endif
 #		endif
 #	endif
 #endif

--- a/data/single_include/lyra/lyra.hpp
+++ b/data/single_include/lyra/lyra.hpp
@@ -103,13 +103,15 @@ struct is_specialization_of<Primary<Args...>, Primary> : std::true_type
 #include <type_traits>
 
 #ifndef LYRA_CONFIG_OPTIONAL_TYPE
-#	ifdef __has_include
-#		if __has_include(<optional>)
-#			include <optional>
-#			if defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
-#				define LYRA_CONFIG_OPTIONAL_TYPE std::optional
-#			endif
-#		endif
+#	if defined(__has_include) && __has_include(<version>)
+#		include <version>
+#	elif defined(__has_include) && __has_include(<ciso646>)
+#		include <ciso646>
+#	endif
+#	if defined(__has_include) && __has_include(<optional>) \
+		&& defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
+#		include <optional>
+#		define LYRA_CONFIG_OPTIONAL_TYPE std::optional
 #	endif
 #endif
 

--- a/data/single_include/lyra/lyra.hpp
+++ b/data/single_include/lyra/lyra.hpp
@@ -254,7 +254,8 @@ inline bool from_string(S const & source, LYRA_CONFIG_OPTIONAL_TYPE<T> & target)
 {
 	std::string srcLC;
 	to_string(source, srcLC);
-	for (std::string::value_type & c : srcLC) c = ::tolower(c);
+	for (std::string::value_type & c : srcLC)
+		c = static_cast<std::string::value_type>(::tolower(c));
 	if (srcLC == "<nullopt>")
 	{
 		target.reset();

--- a/docs/lyra.html
+++ b/docs/lyra.html
@@ -1733,7 +1733,7 @@ want to allow either one of these to be specified:</p>
 <span class="p">{</span>
     <span class="c1">// Default to showing a full screen 4/3 aspect</span>
     <span class="kt">bool</span> <span class="n">show_full_screen</span> <span class="o">=</span> <span class="nb">true</span><span class="p">;</span>
-    <span class="kt">float</span> <span class="n">aspect</span> <span class="o">=</span> <span class="mf">4.0</span><span class="n">f</span> <span class="o">/</span> <span class="mf">3.0</span><span class="n">f</span><span class="p">;</span>
+    <span class="kt">float</span> <span class="n">aspect</span> <span class="o">=</span> <span class="mf">4.0f</span> <span class="o">/</span> <span class="mf">3.0f</span><span class="p">;</span>
 
     <span class="c1">// If it's not full screen the size will be specified.</span>
     <span class="kt">unsigned</span> <span class="n">width</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span>

--- a/include/lyra/detail/from_string.hpp
+++ b/include/lyra/detail/from_string.hpp
@@ -176,7 +176,8 @@ inline bool from_string(S const & source, LYRA_CONFIG_OPTIONAL_TYPE<T> & target)
 {
 	std::string srcLC;
 	to_string(source, srcLC);
-	for (std::string::value_type & c : srcLC) c = ::tolower(c);
+	for (std::string::value_type & c : srcLC)
+		c = static_cast<std::string::value_type>(::tolower(c));
 	if (srcLC == "<nullopt>")
 	{
 		target.reset();

--- a/include/lyra/detail/from_string.hpp
+++ b/include/lyra/detail/from_string.hpp
@@ -16,9 +16,11 @@
 
 #ifndef LYRA_CONFIG_OPTIONAL_TYPE
 #	ifdef __has_include
-#		if __has_include(<optional>) && __cplusplus >= 201703L
+#		if __has_include(<optional>)
 #			include <optional>
-#			define LYRA_CONFIG_OPTIONAL_TYPE std::optional
+#			if defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
+#				define LYRA_CONFIG_OPTIONAL_TYPE std::optional
+#			endif
 #		endif
 #	endif
 #endif

--- a/include/lyra/detail/from_string.hpp
+++ b/include/lyra/detail/from_string.hpp
@@ -15,13 +15,15 @@
 #include <type_traits>
 
 #ifndef LYRA_CONFIG_OPTIONAL_TYPE
-#	ifdef __has_include
-#		if __has_include(<optional>)
-#			include <optional>
-#			if defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
-#				define LYRA_CONFIG_OPTIONAL_TYPE std::optional
-#			endif
-#		endif
+#	if defined(__has_include) && __has_include(<version>)
+#		include <version>
+#	elif defined(__has_include) && __has_include(<ciso646>)
+#		include <ciso646>
+#	endif
+#	if defined(__has_include) && __has_include(<optional>) \
+		&& defined(__cpp_lib_optional) && (__cpp_lib_optional >= 201606L)
+#		include <optional>
+#		define LYRA_CONFIG_OPTIONAL_TYPE std::optional
 #	endif
 #endif
 

--- a/tests/build.jam
+++ b/tests/build.jam
@@ -34,4 +34,6 @@ compile-fail single_include_test.cpp : : single_include_test_fail ;
 compile single_include_test.cpp
 	: <include>../data/single_include ;
 
+run optional_type_test.cpp : requirements <use>/bfg_lyra ;
+
 build-project lib_use_test ;

--- a/tests/optional_type_run_test.cpp
+++ b/tests/optional_type_run_test.cpp
@@ -32,6 +32,12 @@ int main()
 			(REQUIRE( name.has_value() ))
 			(REQUIRE( name.value() == "Pixie" ));
 	}
+	#else
+		#if defined(_MSC_VER)
+			#pragma message("Skipped test because LYRA_CONFIG_OPTIONAL_TYPE is not defined.")
+		#else
+			#warning "Skipped test because LYRA_CONFIG_OPTIONAL_TYPE is not defined."
+		#endif
 	#endif
 
 	return test;

--- a/tests/optional_type_test.cpp
+++ b/tests/optional_type_test.cpp
@@ -33,9 +33,9 @@ int main()
 			(REQUIRE( name.value() == "Pixie" ));
 	}
 	#else
-		#if defined(_MSC_VER)
+		#if defined(_MSC_VER) || defined(__GNUC__)
 			#pragma message("Skipped test because LYRA_CONFIG_OPTIONAL_TYPE is not defined.")
-		#else
+		#elif (__cplusplus >= 202302L)
 			#warning "Skipped test because LYRA_CONFIG_OPTIONAL_TYPE is not defined."
 		#endif
 	#endif


### PR DESCRIPTION
This changes the way that `std::optional` is detected to allow it to work on compilers, like msvc, that incorrectly set, or not set, the __cplusplus def for the language requested and supported to compile. Instead of relying on that macros it uses the feature macro that indicates the level of library implementation for `std::optional`.

Fixes #102 