### PR TITLE
Inform CMake of compatibility with versions newer than 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 # Only need the basic minimum of project, add_library, and
 # target_include_directories commands.
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.5..3.31 )
 
 # Don't set VERSION, as that's a pita to keep up to date with the version
 # header. And don't set LANGUAGES as we are multi-language and header

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 # Only need the basic minimum of project, add_library, and
 # target_include_directories commands.
-cmake_minimum_required( VERSION 3.5..3.31 )
+cmake_minimum_required( VERSION 3.5...4.2.3 )
 
 # Don't set VERSION, as that's a pita to keep up to date with the version
 # header. And don't set LANGUAGES as we are multi-language and header

--- a/tests/lib_use_test/CMakeLists.txt
+++ b/tests/lib_use_test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # http://www.boost.org/LICENSE_1_0.txt
 
 
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.0...4.2.3 )
 project(base_lib_test)
 
 message(STATUS "${CMAKE_PREFIX_PATH}")


### PR DESCRIPTION
Newer versions of CMake complain about version 3.5 being deprecated:
```
CMake Deprecation Warning at build/_deps/lyra-src/CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```
This patch just marks newer versions as supported, silencing this warning.

The `...<policy_max>` syntax was added in 3.12 with earlier versions ignoring it, support for them should not be affected by this change.