### PR TITLE
fix: adjust cmake config installation path to place in the correct dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${PROJECT_SOURCE_DIR}/data/cmake/lyraConfig.cmake.in
   ${PROJECT_BINARY_DIR}/lyraConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/lyra
   )
 
 install(
@@ -60,7 +60,7 @@ install(
   EXPORT lyraTarget
   FILE  lyraTarget.cmake
   NAMESPACE bfg::
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra/cmake
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/lyra
   )
 
 install(
@@ -71,7 +71,7 @@ install(
 install(
   FILES
   ${PROJECT_BINARY_DIR}/lyraConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/lyra/cmake/
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/lyra
   )
 
 


### PR DESCRIPTION
This change adjust the installation path of the Lyra CMake configuration files, which at the current time install to the location:
```
${CMAKE_INSTALL_PREFIX}/share/lyra/cmake/lyraConfig.cmake
${CMAKE_INSTALL_PREFIX}/share/lyra/cmake/lyraTarget.cmake
```
To install in the location:
```
${CMAKE_INSTALL_PREFIX}/share/cmake/lyra/lyraConfig.cmake
${CMAKE_INSTALL_PREFIX}/share/cmake/lyra/lyraConfig.cmake
```

The `share/lyra/cmake/` path isn't useful because it isn't a path that CMake searches for when looking for modules, `share/cmake/*` *is* in the CMake search path. This is a common mistake I see with CMake projects, which typically ends up getting dealt with on a packagers end, but it's a small change, so I figured I would provide it here.