### PR TITLE
Fix unsigned underflow in ostream_printer::option() padding

### DIFF
--- a/data/single_include/lyra/lyra.hpp
+++ b/data/single_include/lyra/lyra.hpp
@@ -1586,8 +1586,10 @@ class ostream_printer : public printer
 	{
 		const std::string indent_str(
 			static_cast<unsigned int>(get_indent_level()) * style.indent_size, ' ');
+		const std::size_t indent_chars
+			= static_cast<std::size_t>(get_indent_level()) * style.indent_size;
 		const std::string opt_pad(
-			26 - static_cast<unsigned int>(get_indent_level()) * style.indent_size - 1, ' ');
+			(indent_chars + 1 < 26) ? (26 - indent_chars - 1) : 0, ' ');
 		if (opt.size() > opt_pad.size())
 			os << indent_str << opt << "\n"
 			   << indent_str << opt_pad << " " << description << "\n";

--- a/include/lyra/printer.hpp
+++ b/include/lyra/printer.hpp
@@ -130,8 +130,10 @@ class ostream_printer : public printer
 	{
 		const std::string indent_str(
 			static_cast<unsigned int>(get_indent_level()) * style.indent_size, ' ');
+		const std::size_t indent_chars
+			= static_cast<std::size_t>(get_indent_level()) * style.indent_size;
 		const std::string opt_pad(
-			26 - static_cast<unsigned int>(get_indent_level()) * style.indent_size - 1, ' ');
+			(indent_chars + 1 < 26) ? (26 - indent_chars - 1) : 0, ' ');
 		if (opt.size() > opt_pad.size())
 			os << indent_str << opt << "\n"
 			   << indent_str << opt_pad << " " << description << "\n";


### PR DESCRIPTION
## Problem

`option_style::indent_size` is a public `std::size_t` field (default `2`) that
users can set to any value. `ostream_printer::option()` in
`include/lyra/printer.hpp` computes the help-text padding width like this:

```cpp
const std::string opt_pad(
    26 - static_cast<unsigned int>(get_indent_level()) * style.indent_size - 1, ' ');
```

The whole right-hand side is evaluated as an unsigned expression. When
`indent_level * indent_size >= 26`, the subtraction wraps around to a huge
value, which is then passed as the character count to
`std::string(count, ' ')` — throwing `std::length_error` and crashing any
program that prints help text with such a style.

### Repro

```cpp
lyra::option_style style = lyra::option_style::posix();
style.indent_size = 26;
cli.style(style);
std::ostringstream oss;
oss << cli; // throws std::length_error: basic_string::_M_create
```

## Fix

Compute the padding size with a saturating subtraction so it degrades to
zero padding instead of underflowing/crashing:

```cpp
const std::size_t indent_chars
    = static_cast<std::size_t>(get_indent_level()) * style.indent_size;
const std::string opt_pad(
    (indent_chars + 1 < 26) ? (26 - indent_chars - 1) : 0, ' ');
```

Output for normal (small indent) usage is byte-for-byte unchanged — verified
by diffing help-text output before/after the fix for default `indent_size`
usage with short/long descriptions and a positional argument.

I also applied the identical change to the generated
`data/single_include/lyra/lyra.hpp` to keep it in sync with
`include/lyra/printer.hpp`, since I didn't have `b2` available locally to
regenerate it per CONTRIBUTING.adoc — happy to drop that hunk if you'd rather
regenerate it yourselves.